### PR TITLE
tip组件和全屏滑动组件 skyline引擎bug修复

### DIFF
--- a/example/pages/index.mpx
+++ b/example/pages/index.mpx
@@ -1,6 +1,12 @@
 <template>
   <theme-container>
-    <view class="introduce" wx:style="{{ { opacity: Number(show) } }}">
+    <scroll-view
+      class="introduce"
+      wx:style="{{ { opacity: Number(show) } }}"
+      wx:enhanced="{{ true }}"
+      scroll-y="{{true}}"
+      wx:show-scrollbar="{{ false }}"
+    >
       <view class="title">
         <view class="logo"></view>
       </view>
@@ -26,7 +32,7 @@
         list="{{ themeList }}"
         wx:ref="pickerPopup"
         bindvalueChange="onThemeChange"></cube-picker-modal>
-    </view>
+    </scroll-view>
   </theme-container>
 </template>
 
@@ -36,8 +42,12 @@
   @require '@mpxjs/mpx-cube-ui/src/common/stylus/mixin.styl'
 
   .introduce
+    box-sizing border-box
+    position relative
     padding 6px 20px 6px 20px
     background-color #f7f8fa
+    height 100 vh
+    width 100 vw
     .title
       display flex
       align-items center

--- a/packages/mpx-cube-ui/src/components/tip/index.mpx
+++ b/packages/mpx-cube-ui/src/components/tip/index.mpx
@@ -6,7 +6,9 @@
     bind:animationend="onAnimationEnd"
     bind:tap="onClick"
   >
-    <view class="cube-tip-angle" wx:style="{{ angStyle }}"></view>
+    <view class="cube-tip-angle" wx:style="{{ angStyle }}">
+      <view class="cube-tip-arrow"></view>
+    </view>
     <cube-icon
       class="cube-tip-close"
       theme-type="{{ themeType }}"
@@ -48,13 +50,13 @@
   &.cube-tip-direction_top
     .cube-tip-angle
       top 0
-      &::before
+      .cube-tip-arrow
         margin-top $var(tip-vertical-reverse-margin)
         transform rotate(0deg)
   &.cube-tip-direction_bottom
     .cube-tip-angle
       bottom 0
-      &::before
+      .cube-tip-arrow
         margin-bottom $var(tip-vertical-reverse-margin)
         transform rotate(180deg)
   &.cube-tip-direction_left,
@@ -65,18 +67,18 @@
   &.cube-tip-direction_left
     .cube-tip-angle
       left 0
-      &::before
+      .cube-tip-arrow
         margin-left $var(tip-horizontal-reverse-margin)
         transform rotate(-90deg)
   &.cube-tip-direction_right
     .cube-tip-angle
       right 0
-      &::before
+      .cube-tip-arrow
         margin-right $var(tip-horizontal-reverse-margin)
         transform rotate(90deg)
 .cube-tip-angle
   position absolute
-  &::before
+  .cube-tip-arrow
     display block
     border-width $var(tip-angle-border-width)
     border-style $var(tip-angle-border-style)
@@ -97,8 +99,9 @@
 .cube-tip-content
   min-height $var(tip-content-min-height)
   line-height $var(tip-content-line-height)
-  flex-fix()
+  // flex-fix()
   overflow hidden
+  flex 1 1 auto
 
 .scale-enter
   animation scale-in .4s

--- a/packages/mpx-cube-ui/src/components/tip/index.mpx
+++ b/packages/mpx-cube-ui/src/components/tip/index.mpx
@@ -101,7 +101,8 @@
   line-height $var(tip-content-line-height)
   // flex-fix()
   overflow hidden
-  flex 1 1 auto
+  flex 1
+  min-width 0
 
 .scale-enter
   animation scale-in .4s

--- a/packages/mpx-cube-ui/src/components/tip/index.mpx
+++ b/packages/mpx-cube-ui/src/components/tip/index.mpx
@@ -6,8 +6,8 @@
     bind:animationend="onAnimationEnd"
     bind:tap="onClick"
   >
-    <view class="cube-tip-angle" wx:style="{{ angStyle }}">
-      <view class="cube-tip-arrow"></view>
+    <view class="cube-tip-angle-wapper" wx:style="{{ angStyle }}">
+      <view class="cube-tip-angle"></view>
     </view>
     <cube-icon
       class="cube-tip-close"
@@ -44,41 +44,41 @@
   color $var(tip-color)
   &.cube-tip-direction_top,
   &.cube-tip-direction_bottom
-    .cube-tip-angle
+    .cube-tip-angle-wapper
       left 50%
       transform translateX(-50%)
   &.cube-tip-direction_top
-    .cube-tip-angle
+    .cube-tip-angle-wapper
       top 0
-      .cube-tip-arrow
+      .cube-tip-angle
         margin-top $var(tip-vertical-reverse-margin)
         transform rotate(0deg)
   &.cube-tip-direction_bottom
-    .cube-tip-angle
+    .cube-tip-angle-wapper
       bottom 0
-      .cube-tip-arrow
+      .cube-tip-angle
         margin-bottom $var(tip-vertical-reverse-margin)
         transform rotate(180deg)
   &.cube-tip-direction_left,
   &.cube-tip-direction_right
-    .cube-tip-angle
+    .cube-tip-angle-wapper
       top 50%
       transform translateY(-50%)
   &.cube-tip-direction_left
-    .cube-tip-angle
+    .cube-tip-angle-wapper
       left 0
-      .cube-tip-arrow
+      .cube-tip-angle
         margin-left $var(tip-horizontal-reverse-margin)
         transform rotate(-90deg)
   &.cube-tip-direction_right
-    .cube-tip-angle
+    .cube-tip-angle-wapper
       right 0
-      .cube-tip-arrow
+      .cube-tip-angle
         margin-right $var(tip-horizontal-reverse-margin)
         transform rotate(90deg)
-.cube-tip-angle
+.cube-tip-angle-wapper
   position absolute
-  .cube-tip-arrow
+  .cube-tip-angle
     display block
     border-width $var(tip-angle-border-width)
     border-style $var(tip-angle-border-style)


### PR DESCRIPTION
1. wx skyline渲染引擎所有的滑动组件都需要使用scroll-view标签来包裹
2. wx skyline渲染引擎对于所有节点都增加position：relavtive，且box-sizer：border-box
3. wx skyline渲染引擎对于伪类元素仅仅支持:nth-child伪类元素，不支持:after :before等元素